### PR TITLE
fix: add window check before initializing app check in production

### DIFF
--- a/firebase/initFirebase.ts
+++ b/firebase/initFirebase.ts
@@ -70,7 +70,7 @@ export default function initFirebase(): FirebaseApp {
         
         // If we are in production and appcheck is not initialized, check if we need to initialize it
         // This handles the case where Firebase was initialized elsewhere but appcheck wasn't 
-        if (process.env.NODE_ENV === 'production' && !appcheck) {
+        if (typeof window !== 'undefined' && process.env.NODE_ENV === 'production' && !appcheck) {
             console.log("Initializing App Check for existing Firebase app in production");
             try {
                 appcheck = initializeAppCheck(app, {


### PR DESCRIPTION
Added a check for `typeof window !== 'undefined'` before attempting to initialize App Check in production environment. This prevents errors when the code runs server-side where the window object is not available, ensuring proper Firebase initialization flow in both client and server environments.