### PR TITLE
feat(firebase): add admin firestore utilities and update album pages …

### DIFF
--- a/firebase/firebaseAdmin.ts
+++ b/firebase/firebaseAdmin.ts
@@ -1,6 +1,7 @@
 import { initializeApp, cert, App, getApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
+import type { Firestore } from 'firebase-admin/firestore';
 
 const firebasePrivateKey = process.env.FIREBASE_PRIVATE_KEY
 
@@ -37,3 +38,16 @@ export const getIsAdmin = async (userId: string): Promise<boolean> => {
 }
 
 export default initApp;
+
+export const getAdminFirestore = (): Firestore => {
+    const app = initApp();
+    return getFirestore(app);
+};
+
+export const adminGetDocument = async <T>(path: string, docId: string): Promise<T | undefined> => {
+    const docSnap = await getAdminFirestore().doc(`${path}/${docId}`).get();
+    if (docSnap.exists) {
+        return docSnap.data() as T;
+    }
+    return undefined;
+};

--- a/pages/album/[aid].tsx
+++ b/pages/album/[aid].tsx
@@ -1,4 +1,3 @@
-import { where } from 'firebase/firestore'
 import { GetStaticProps, InferGetStaticPropsType } from 'next'
 import Link from 'next/link'
 import { useState } from 'react'
@@ -7,9 +6,9 @@ import HeadTag from '../../components/ui/headTag'
 import PostUserInfo from '../../components/ui/postUserInfo'
 import { getImageBucketUrl } from '../../components/ui/showImage'
 import { jsonLdDateFormat, uiDateFormat } from '../../components/ui/uiUtils'
-import { getDocument, queryOnce } from '../../firebase/firestore'
+import { adminGetDocument, getAdminFirestore } from '../../firebase/firebaseAdmin'
 import { User } from '../../firebase/types'
-import { AlbumType } from '../account/editAlbum'
+import type { AlbumType } from '../account/editAlbum'
 import styles from '../../styles/AlbumDetails.module.css'
 
 type AlbumPropType = {
@@ -20,14 +19,12 @@ type AlbumPropType = {
 }
 
 export async function getStaticPaths() {
-    const topPosts = await queryOnce<AlbumType>({
-        path: `albums`,
-        queryConstraints: [
-            where("public", "==", true),
-            where("approved", "==", true)
-        ]
-    })
-    const paths = topPosts.map(post => ({ params: { aid: post.id } }))
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('albums')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .get();
+    const paths = snapshot.docs.map(doc => ({ params: { aid: doc.id } }))
     return {
         paths,
         fallback: 'blocking', // generate new pages on-demand
@@ -36,7 +33,7 @@ export async function getStaticPaths() {
 
 export const getStaticProps = (async (context) => {
     const aid = context.params.aid as string;
-    const albumDoc = await getDocument<AlbumType>({ path: `albums`, pathSegments: [aid] })
+    const albumDoc = await adminGetDocument<AlbumType>('albums', aid)
 
     if (!albumDoc) {
         return {
@@ -50,7 +47,7 @@ export const getStaticProps = (async (context) => {
         };
     }
 
-    const userDoc = await getDocument<User>({ path: `users`, pathSegments: [albumDoc.userId] })
+    const userDoc = await adminGetDocument<User>('users', albumDoc.userId)
 
     if (!userDoc) {
         return {

--- a/pages/albums.tsx
+++ b/pages/albums.tsx
@@ -2,9 +2,8 @@ import AlbumList from '../components/ui/albumList';
 import HeadTag from '../components/ui/headTag';
 import EmptyState from '../components/ui/EmptyState';
 import { uiDateFormat } from '../components/ui/uiUtils';
-import { queryOnce } from '../firebase/firestore';
-import { AlbumType } from './account/editAlbum';
-import { where } from 'firebase/firestore';
+import type { AlbumType } from './account/editAlbum';
+import { getAdminFirestore } from '../firebase/firebaseAdmin';
 import { InferGetStaticPropsType } from 'next';
 import { getImageBucketUrl } from '../components/ui/showImage2';
 import styles from '../styles/AlbumsPage.module.css';
@@ -48,13 +47,12 @@ export default function Page({
 }
 
 export async function getStaticProps() {
-    const dbList = await queryOnce<AlbumType>({
-        path: `albums`,
-        queryConstraints: [
-            where("public", "==", true),
-            where("approved", "==", true)
-        ]
-    })
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('albums')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .get();
+    const dbList = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as AlbumType) }));
     const bucketUrlMap = {}
     dbList.forEach(x => {
         const url = getImageBucketUrl(x.images[0], 's', x.userId);

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -1,5 +1,5 @@
-import { getEvents } from '../service/PostService';
-import { Event } from '../service/PostService';
+import { getEventsAdmin } from '../service/PostServiceAdmin';
+import type { Event } from '../service/PostService';
 import HeadTag from '../components/ui/headTag';
 import EventList from '../components/ui/eventList';
 
@@ -53,7 +53,7 @@ export default function EventsPage({ events }: EventsPageProps) {
 }
 
 export async function getStaticProps() {
-    const events = await getEvents({ limit: 50 }); // Fetch up to 50 upcoming events
+    const events = await getEventsAdmin({ limit: 50 }); // Fetch up to 50 upcoming events
     return {
         props: {
             events,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,8 +2,8 @@ import HeadTag from '../components/ui/headTag';
 import Image from 'next/image';
 import Link from 'next/link';
 import styles from '../styles/IndexDev.module.css';
-import { getDocument } from '../firebase/firestore';
-import { getAlbums, getEvents, getNews, getPostsWithDetails } from '../service/PostService';
+import { adminGetDocument } from '../firebase/firebaseAdmin';
+import { getAlbumsAdmin, getEventsAdmin, getNewsAdmin, getPostsWithDetailsAdmin } from '../service/PostServiceAdmin';
 import { CSSProperties, useEffect, useState } from 'react';
 import { Weather } from './weather/[id]';
 import { uiRound } from '../components/ui/uiUtils';
@@ -293,11 +293,11 @@ function IndexDev({ posts = [], news = [], events = [], albums = [], data = defa
 export default IndexDev;
 
 export async function getStaticProps() {
-  const resp = await getDocument<HomepageConfig>({ path: 'appconfig', pathSegments: ['homepage'] });
-  const postDisplay = await getPostsWithDetails();
-  const news = await getNews({ limit: 8, preferredApiSource: 'newsdata.io' });
-  const events = await getEvents({ limit: 4 });
-  const allAlbums = await getAlbums({ limit: 12 });
+  const resp = await adminGetDocument<HomepageConfig>('appconfig', 'homepage');
+  const postDisplay = await getPostsWithDetailsAdmin();
+  const news = await getNewsAdmin({ limit: 8, preferredApiSource: 'newsdata.io' });
+  const events = await getEventsAdmin({ limit: 4 });
+  const allAlbums = await getAlbumsAdmin({ limit: 12 });
   const albums = allAlbums.filter(a => a.images && a.images.length > 0).slice(0, 6);
 
   return {

--- a/pages/news/[page].tsx
+++ b/pages/news/[page].tsx
@@ -1,5 +1,5 @@
-import { getPaginatedNews } from '../../service/PostService';
-import { NewsArticle } from '../../service/PostService';
+import { getPaginatedNewsAdmin } from '../../service/PostServiceAdmin';
+import type { NewsArticle } from '../../service/PostService';
 import HeadTag from '../../components/ui/headTag';
 import NewsList from '../../components/ui/newsList';
 import Pagination from '../../components/ui/pagination';
@@ -60,7 +60,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     if (isNaN(page) || page < 1) {
         return { notFound: true };
     }
-    const { news, totalCount } = await getPaginatedNews({ limit: NEWS_PER_PAGE, page });
+    const { news, totalCount } = await getPaginatedNewsAdmin({ limit: NEWS_PER_PAGE, page });
 
     const totalPages = Math.ceil(Math.min(totalCount, MAX_NEWS_ITEMS) / NEWS_PER_PAGE);
 

--- a/pages/post/[category]/[slug].tsx
+++ b/pages/post/[category]/[slug].tsx
@@ -6,12 +6,10 @@ import HeadTag from "../../../components/ui/headTag";
 import PostUserInfo from "../../../components/ui/postUserInfo";
 import RecentPostsBox from "../../../components/ui/recentPostsBox";
 import Link from "next/link";
-import { limit, where } from 'firebase/firestore';
-
 import { jsonLdDateFormat, uiDateFormat } from "../../../components/ui/uiUtils";
-import { getDocument, queryOnce } from "../../../firebase/firestore";
+import { adminGetDocument, getAdminFirestore } from "../../../firebase/firebaseAdmin";
 import { PostDisplayType, PostType, User } from "../../../firebase/types";
-import { getPostBySlug, getPosts } from "../../../service/PostService";
+import { getPostBySlugAdmin, getPostsAdmin } from "../../../service/PostServiceAdmin";
 import ShowImage2, { ImageDisplayType, getImageBucketUrl } from '../../../components/ui/showImage2';
 
 type PageType = PostDisplayType & {
@@ -31,7 +29,7 @@ export async function getStaticPaths() {
     // what pages are generated during the build or on-demand
     // For example, you could only generate the top products
     // const topProducts = await getTopProducts()
-    const topPosts = await getPosts({ limit: 20, public: true });
+    const topPosts = await getPostsAdmin({ limit: 20 });
     const paths = topPosts.map(post => ({ params: { category: post.category, slug: post.slug } }))
     return {
         paths,
@@ -40,15 +38,14 @@ export async function getStaticPaths() {
 }
 
 export const getStaticProps = (async (context) => {
-    const postDoc = await getPostBySlug(context.params.category as string, context.params.slug as string);
+    const postDoc = await getPostBySlugAdmin(context.params.category as string, context.params.slug as string);
     const draftRaw = JSON.parse(postDoc.edState);
     const postBody = draftToHtml(draftRaw);
     const authorPromise: Promise<User> = (async () => {
-        const byUserIdField = await queryOnce<User>({
-            path: 'users',
-            queryConstraints: [where('id', '==', postDoc.userId), limit(1)]
-        });
-        const byDocId = await getDocument<User>({ path: 'users', pathSegments: [postDoc.userId] });
+        const db = getAdminFirestore();
+        const byUserIdSnap = await db.collection('users').where('id', '==', postDoc.userId).limit(1).get();
+        const byUserIdField = byUserIdSnap.docs.map(d => ({ id: d.id, ...(d.data() as User) }));
+        const byDocId = await adminGetDocument<User>('users', postDoc.userId);
         const resolved = byUserIdField[0] || byDocId;
 
         if (!resolved) {
@@ -81,7 +78,7 @@ export const getStaticProps = (async (context) => {
             profilePic: resolved.profilePic,
         };
     })();
-    const recentPostsPromise = getPosts({ limit: 5, public: true });
+    const recentPostsPromise = getPostsAdmin({ limit: 5 });
     const imagesPromise: Promise<ImageDisplayType[]> = (async () => {
         const { probeRemoteImage } = await import('../../../lib/imageProbe');
         return Promise.all(

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -1,5 +1,5 @@
 import ShowImage from "../../components/ui/showImage";
-import { getDocument } from "../../firebase/firestore";
+import { adminGetDocument } from "../../firebase/firebaseAdmin";
 import { PostType } from "../../firebase/types";
 import DOMPurify from 'isomorphic-dompurify';
 import { Col, Container, Row } from "../../components/ui/tw";
@@ -8,7 +8,7 @@ import Link from "next/link";
 import HeadTag from "../../components/ui/headTag";
 
 import PostUserInfo from "../../components/ui/postUserInfo";
-import { getPosts } from "../../service/PostService";
+import { getPostsAdmin, getPostWithAuthorAdmin } from "../../service/PostServiceAdmin";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { ParsedUrlQuery } from "querystring";
 
@@ -29,7 +29,7 @@ export async function getStaticPaths() {
     // what pages are generated during the build or on-demand
     // For example, you could only generate the top products
     // const topProducts = await getTopProducts()
-    const topPosts = await getPosts({ limit: 20, public: true });
+    const topPosts = await getPostsAdmin({ limit: 20 });
     const paths = topPosts.map(post => ({ params: { id: post.id } }))
     return {
         paths,
@@ -37,11 +37,9 @@ export async function getStaticPaths() {
     }
 }
 
-import { getPostWithAuthor } from '../../service/PostService';
-
 export const getStaticProps: GetStaticProps = async (context) => {
     const { id } = context.params as IParams;
-    const post = await getDocument<PostType>({ path: 'posts', pathSegments: [id] });
+    const post = await adminGetDocument<PostType>('posts', id);
 
     if (!post) {
         return {
@@ -49,7 +47,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
         };
     }
 
-    const postDisplay = await getPostWithAuthor(post);
+    const postDisplay = await getPostWithAuthorAdmin(post);
     return {
         props: {
             post: postDisplay,

--- a/pages/posts/page/[page].tsx
+++ b/pages/posts/page/[page].tsx
@@ -1,5 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
-import { getPaginatedPosts } from '../../../service/PostService';
+import { getPaginatedPostsAdmin } from '../../../service/PostServiceAdmin';
 import Pagination from '../../../components/ui/pagination';
 import PublicPostList from '../../../components/ui/publicPostList';
 import HeadTag from '../../../components/ui/headTag';
@@ -70,7 +70,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
         return { notFound: true };
     }
     const page = Number(pageParam);
-    const { posts, totalCount } = await getPaginatedPosts({ limit: 12, page });
+    const { posts, totalCount } = await getPaginatedPostsAdmin({ limit: 12, page });
 
     return {
         props: {
@@ -83,7 +83,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-    const { totalCount } = await getPaginatedPosts({ limit: 12, page: 1 });
+    const { totalCount } = await getPaginatedPostsAdmin({ limit: 12, page: 1 });
     const totalPages = Math.ceil(totalCount / 12);
 
     const paths = Array.from({ length: totalPages }, (_, i) => ({

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,7 +1,6 @@
-import { where } from "firebase/firestore";
-import { queryOnce } from "../firebase/firestore";
+import { getAdminFirestore } from "../firebase/firebaseAdmin";
 import { PostType } from "../firebase/types";
-import { AlbumType } from "./account/editAlbum";
+import type { AlbumType } from "./account/editAlbum";
 
 const DEFAULT_SITE_URL = 'https://www.roorkee.org';
 
@@ -123,24 +122,13 @@ function SiteMap() {
 
 export async function getServerSideProps({ res }) {
     const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || DEFAULT_SITE_URL).replace(/\/+$/, '');
-    const postsPromise = queryOnce<PostType>(
-        {
-            path: `posts`, queryConstraints: [
-                where("public", "==", true)
-            ]
-        }
-    )
-
-    const albumsPromise = queryOnce<AlbumType>(
-        {
-            path: `albums`, queryConstraints: [
-                where("public", "==", true),
-                where("approved", "==", true)
-            ]
-        }
-    )
-
-    const [posts, albums] = await Promise.all([postsPromise, albumsPromise]);
+    const db = getAdminFirestore();
+    const [postsSnap, albumsSnap] = await Promise.all([
+        db.collection('posts').where('public', '==', true).get(),
+        db.collection('albums').where('public', '==', true).where('approved', '==', true).get(),
+    ]);
+    const posts = postsSnap.docs.map(d => ({ id: d.id, ...(d.data() as PostType) }));
+    const albums = albumsSnap.docs.map(d => ({ id: d.id, ...(d.data() as AlbumType) }));
 
     // We generate the XML sitemap with the posts data
     const sitemap = generateSiteMap(siteUrl, posts, albums);

--- a/pages/user/[id].tsx
+++ b/pages/user/[id].tsx
@@ -1,15 +1,13 @@
-import { orderBy, where } from "firebase/firestore";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import Link from "next/link";
 import { Col, Container, Image, Row } from "../../components/ui/tw";
 import HeadTag from "../../components/ui/headTag";
 import RecentPostsBox from "../../components/ui/recentPostsBox";
 import { uiDateFormat } from "../../components/ui/uiUtils";
-import { getDocument, queryOnce } from "../../firebase/firestore";
-import { User } from "../../firebase/types";
-import { getPosts } from "../../service/PostService";
-import { AlbumType } from "../account/editAlbum";
-import { PostType } from "../../firebase/types";
+import { adminGetDocument, getAdminFirestore } from "../../firebase/firebaseAdmin";
+import { User, PostType } from "../../firebase/types";
+import { getPostsAdmin } from "../../service/PostServiceAdmin";
+import type { AlbumType } from "../account/editAlbum";
 
 type UserPropType = {
     user: User,
@@ -20,8 +18,9 @@ type UserPropType = {
 }
 
 export async function getStaticPaths() {
-    const users = await queryOnce<User>({ path: 'users' });
-    const paths = users.map(user => ({ params: { id: user.id } }))
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('users').get();
+    const paths = snapshot.docs.map(doc => ({ params: { id: doc.id } }))
     return {
         paths,
         fallback: 'blocking', // generate new pages on-demand
@@ -30,30 +29,22 @@ export async function getStaticPaths() {
 
 export const getStaticProps = (async (context) => {
     const userId = context.params.id as string;
-    const userPromise = getDocument<User>({ path: `users`, pathSegments: [userId] })
-    //Get posts of this user
-    const postsPromise = queryOnce<PostType>(
-        {
-            path: `posts`, queryConstraints: [
-                where("public", "==", true),
-                where("userId", "==", userId),
-                orderBy("updateDate", "desc")
-            ]
-        });
-
-
-    //Get albums of this user
-    const albumsPromise = queryOnce<AlbumType>(
-        {
-            path: `albums`, queryConstraints: [
-                where("public", "==", true),
-                where("approved", "==", true),
-                where("userId", "==", userId),
-                orderBy("updateDate", "desc")
-            ]
-        });
-
-    const recentPostsPromise = getPosts({ limit: 5, public: true });
+    const db = getAdminFirestore();
+    const userPromise = adminGetDocument<User>('users', userId);
+    const postsPromise = db.collection('posts')
+        .where('public', '==', true)
+        .where('userId', '==', userId)
+        .orderBy('updateDate', 'desc')
+        .get()
+        .then(snap => snap.docs.map(d => ({ id: d.id, ...(d.data() as PostType) })));
+    const albumsPromise = db.collection('albums')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .where('userId', '==', userId)
+        .orderBy('updateDate', 'desc')
+        .get()
+        .then(snap => snap.docs.map(d => ({ id: d.id, ...(d.data() as AlbumType) })));
+    const recentPostsPromise = getPostsAdmin({ limit: 5 });
 
     const [user, posts, albums, recentPosts] = await Promise.all([userPromise, postsPromise, albumsPromise, recentPostsPromise])
 

--- a/pages/users/[userid]/profile/index.tsx
+++ b/pages/users/[userid]/profile/index.tsx
@@ -1,15 +1,13 @@
-import { orderBy, where } from "firebase/firestore";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import Link from "next/link";
 import { Col, Container, Image, Row } from "../../../../components/ui/tw";
 import HeadTag from "../../../../components/ui/headTag";
 import RecentPostsBox from "../../../../components/ui/recentPostsBox";
 import { uiDateFormat } from "../../../../components/ui/uiUtils";
-import { getDocument, queryOnce } from "../../../../firebase/firestore";
-import { User } from "../../../../firebase/types";
-import { getPosts } from "../../../../service/PostService";
-import { AlbumType } from "../../../account/editAlbum";
-import { PostType } from "../../../../firebase/types";
+import { adminGetDocument, getAdminFirestore } from "../../../../firebase/firebaseAdmin";
+import { User, PostType } from "../../../../firebase/types";
+import { getPostsAdmin } from "../../../../service/PostServiceAdmin";
+import type { AlbumType } from "../../../account/editAlbum";
 
 type UserPropType = {
     user: User,
@@ -20,8 +18,9 @@ type UserPropType = {
 }
 
 export async function getStaticPaths() {
-    const users = await queryOnce<User>({ path: 'users' });
-    const paths = users.map(user => ({ params: { userid: user.id } }))
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('users').get();
+    const paths = snapshot.docs.map(doc => ({ params: { userid: doc.id } }))
     return {
         paths,
         fallback: 'blocking', // generate new pages on-demand
@@ -30,30 +29,22 @@ export async function getStaticPaths() {
 
 export const getStaticProps = (async (context) => {
     const userId = context.params.userid as string;
-    const userPromise = getDocument<User>({ path: `users`, pathSegments: [userId] })
-    //Get posts of this user
-    const postsPromise = queryOnce<PostType>(
-        {
-            path: `posts`, queryConstraints: [
-                where("public", "==", true),
-                where("userId", "==", userId),
-                orderBy("updateDate", "desc")
-            ]
-        });
-
-
-    //Get albums of this user
-    const albumsPromise = queryOnce<AlbumType>(
-        {
-            path: `albums`, queryConstraints: [
-                where("public", "==", true),
-                where("approved", "==", true),
-                where("userId", "==", userId),
-                orderBy("updateDate", "desc")
-            ]
-        });
-
-    const recentPostsPromise = getPosts({ limit: 5, public: true });
+    const db = getAdminFirestore();
+    const userPromise = adminGetDocument<User>('users', userId);
+    const postsPromise = db.collection('posts')
+        .where('public', '==', true)
+        .where('userId', '==', userId)
+        .orderBy('updateDate', 'desc')
+        .get()
+        .then(snap => snap.docs.map(d => ({ id: d.id, ...(d.data() as PostType) })));
+    const albumsPromise = db.collection('albums')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .where('userId', '==', userId)
+        .orderBy('updateDate', 'desc')
+        .get()
+        .then(snap => snap.docs.map(d => ({ id: d.id, ...(d.data() as AlbumType) })));
+    const recentPostsPromise = getPostsAdmin({ limit: 5 });
 
     const [user, posts, albums, recentPosts] = await Promise.all([userPromise, postsPromise, albumsPromise, recentPostsPromise])
 

--- a/pages/weather/[id].tsx
+++ b/pages/weather/[id].tsx
@@ -1,6 +1,6 @@
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import { Card, Col, Container, Image, Row } from "../../components/ui/tw";
-import { getDocument } from '../../firebase/firestore';
+import { adminGetDocument } from '../../firebase/firebaseAdmin';
 import { uiRound, uiDateFormat } from '../../components/ui/uiUtils';
 import Head from 'next/head';
 
@@ -214,7 +214,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 };
 
 export const getStaticProps: GetStaticProps<{ weather: Weather | null; lastUpdated: string }> = async () => {
-    const weather = await getDocument<Weather>({ path: 'weather', pathSegments: ['roorkee-in'] });
+    const weather = await adminGetDocument<Weather>('weather', 'roorkee-in');
     return {
         props: {
             weather: weather ?? null,

--- a/service/PostServiceAdmin.ts
+++ b/service/PostServiceAdmin.ts
@@ -1,0 +1,274 @@
+import type { PostType, User, PostDisplayType } from '../firebase/types';
+import type { AlbumType } from '../pages/account/editAlbum';
+import type { Event, NewsArticle } from './PostService';
+import { getAdminFirestore } from '../firebase/firebaseAdmin';
+import { getImageBucketUrl } from '../components/ui/imageUtils';
+import type { ImageSize } from '../components/ui/imageUtils';
+import { uiDateFormat } from '../components/ui/uiUtils';
+
+// Title dedup utilities — mirrors PostService.ts (pure functions, no SDK deps)
+const STOP_WORDS = new Set([
+    "the","a","an","to","of","in","on","for","with","and","or","at","from","by","about","after","before","over","under","into","as","is","are","was","were","be","been","being","this","that","these","those","it","its","their","his","her","new","breaking"
+]);
+
+function normalizeTitle(raw: string): string {
+    if (!raw) return "";
+    return raw
+        .toLowerCase()
+        .replace(/https?:\/\/\S+/g, " ")
+        .replace(/[^a-z0-9\s]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+function tokenizeTitle(raw: string): string[] {
+    return normalizeTitle(raw).split(" ").filter(t => t && !STOP_WORDS.has(t));
+}
+
+function jaccardSimilarity(a: string[], b: string[]): number {
+    if (a.length === 0 && b.length === 0) return 1;
+    const aSet = new Set(a);
+    const bSet = new Set(b);
+    let intersection = 0;
+    for (const t of aSet) { if (bSet.has(t)) intersection++; }
+    const union = aSet.size + bSet.size - intersection;
+    return union === 0 ? 0 : intersection / union;
+}
+
+function tokenCoverage(a: string[], b: string[]): number {
+    if (a.length === 0 || b.length === 0) return 0;
+    const aSet = new Set(a);
+    const bSet = new Set(b);
+    let intersection = 0;
+    for (const t of aSet) { if (bSet.has(t)) intersection++; }
+    const minLen = Math.min(aSet.size, bSet.size);
+    return minLen === 0 ? 0 : intersection / minLen;
+}
+
+function areTitlesSimilar(a: string, b: string): boolean {
+    const an = normalizeTitle(a);
+    const bn = normalizeTitle(b);
+    if (!an || !bn) return false;
+    if (an === bn) return true;
+    const at = tokenizeTitle(a);
+    const bt = tokenizeTitle(b);
+    if (at.length === 0 || bt.length === 0) return an === bn;
+    return jaccardSimilarity(at, bt) >= 0.75 || tokenCoverage(at, bt) >= 0.85;
+}
+
+function dedupeBySimilarTitle<T extends { title: string }>(items: T[]): T[] {
+    const result: T[] = [];
+    for (const item of items) {
+        if (!result.some(r => areTitlesSimilar(r.title, item.title))) result.push(item);
+    }
+    return result;
+}
+
+function getImageUrls(items: Array<{ userId: string; images?: string[] }>, size: ImageSize): string[][] {
+    return items.map(item => {
+        if (!item.images || item.images.length === 0) return [];
+        return [getImageBucketUrl(item.images[0], size, item.userId)];
+    });
+}
+
+export async function getPostsWithDetailsAdmin(
+    args: { limit?: number; photoSize?: ImageSize } = { limit: 10, photoSize: 's' }
+): Promise<PostDisplayType[]> {
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('posts')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .orderBy('updateDate', 'desc')
+        .limit(args.limit ?? 10)
+        .get();
+
+    const posts = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as PostType) }));
+
+    const userIds = [...new Set(posts.map(p => p.userId))].filter(Boolean);
+    const users: User[] = [];
+    if (userIds.length > 0) {
+        const usersSnap = await db.collection('users').where('id', 'in', userIds).get();
+        usersSnap.docs.forEach(doc => users.push({ id: doc.id, ...(doc.data() as User) }));
+    }
+    const userDict = users.reduce((dict, u) => { dict[u.id] = u; return dict; }, {} as Record<string, User>);
+
+    const imageUrls = getImageUrls(posts, args.photoSize ?? 's');
+    return posts.map((post, i) => ({
+        ...post,
+        images: imageUrls[i],
+        formattedUpdateDate: uiDateFormat(post.updateDate),
+        author: userDict[post.userId],
+    }));
+}
+
+export async function getNewsAdmin(
+    args: { limit: number; preferredApiSource?: string } = { limit: 8 }
+): Promise<NewsArticle[]> {
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('news')
+        .orderBy('expireAt', 'desc')
+        .limit(args.limit * 4)
+        .get();
+
+    const news = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as NewsArticle) }));
+    const deduped = dedupeBySimilarTitle(news);
+
+    const prioritized = args.preferredApiSource
+        ? deduped.sort((a, b) => {
+            const aRank = a.apiSource === args.preferredApiSource ? 0 : 1;
+            const bRank = b.apiSource === args.preferredApiSource ? 0 : 1;
+            if (aRank !== bRank) return aRank - bRank;
+            return (b.expireAt || 0) - (a.expireAt || 0);
+        })
+        : deduped;
+
+    return prioritized.slice(0, args.limit).map(article => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { expireAt, ...rest } = article;
+        return { ...rest, formattedPubDate: uiDateFormat(new Date(article.publishedAt).getTime()) };
+    });
+}
+
+export async function getEventsAdmin(
+    args: { limit: number } = { limit: 8 }
+): Promise<Event[]> {
+    const db = getAdminFirestore();
+    const today = new Date().toISOString().split('T')[0];
+    const snapshot = await db.collection('events')
+        .where('date', '>=', today)
+        .orderBy('date', 'asc')
+        .limit(args.limit)
+        .get();
+
+    return snapshot.docs.map(doc => {
+        const data = doc.data() as Event;
+        const eventDate = new Date(data.date);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { expireAt, ...rest } = data;
+        return {
+            ...rest,
+            id: doc.id,
+            formattedDate: uiDateFormat(eventDate.getTime()),
+            formattedMonth: eventDate.toLocaleString('default', { month: 'short' }).toUpperCase(),
+            formattedDay: eventDate.getDate().toString(),
+            formattedYear: eventDate.getFullYear().toString(),
+        };
+    });
+}
+
+export async function getAlbumsAdmin(
+    args: { limit: number } = { limit: 6 }
+): Promise<AlbumType[]> {
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('albums')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .orderBy('updateDate', 'desc')
+        .limit(args.limit)
+        .get();
+
+    const albums = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as AlbumType) }));
+    const imageUrls = getImageUrls(albums, 's');
+    return albums.map((album, i) => ({ ...album, images: imageUrls[i] }));
+}
+
+export async function getPostsAdmin(
+    args: { limit?: number } = {}
+): Promise<PostType[]> {
+    const db = getAdminFirestore();
+    let q = db.collection('posts')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .orderBy('updateDate', 'desc');
+    if (args.limit) q = q.limit(args.limit);
+    const snapshot = await q.get();
+    return snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as PostType) }));
+}
+
+export async function getPostBySlugAdmin(category: string, slug: string): Promise<PostType | undefined> {
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('posts')
+        .where('category', '==', category)
+        .where('slug', '==', slug)
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .limit(1)
+        .get();
+    if (snapshot.empty) return undefined;
+    const doc = snapshot.docs[0];
+    return { id: doc.id, ...(doc.data() as PostType) };
+}
+
+export async function getPostWithAuthorAdmin(post: PostType): Promise<PostDisplayType> {
+    const db = getAdminFirestore();
+    const usersSnap = await db.collection('users').where('id', '==', post.userId).get();
+    const authorDoc = usersSnap.docs[0];
+    const author: User = authorDoc
+        ? { id: authorDoc.id, ...(authorDoc.data() as User) }
+        : { id: post.userId, email: '', name: 'Community Member', profilePic: undefined };
+    const imageUrls = getImageUrls([post], 'l');
+    return {
+        ...post,
+        images: imageUrls[0],
+        formattedUpdateDate: uiDateFormat(post.updateDate),
+        author,
+    };
+}
+
+export async function getPaginatedPostsAdmin(
+    args: { limit: number; page: number }
+): Promise<{ posts: PostDisplayType[]; totalCount: number }> {
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('posts')
+        .where('public', '==', true)
+        .where('approved', '==', true)
+        .orderBy('updateDate', 'desc')
+        .get();
+
+    const allPosts = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as PostType) }));
+    const totalCount = allPosts.length;
+    const start = (args.page - 1) * args.limit;
+    const paginatedPosts = allPosts.slice(start, start + args.limit);
+
+    const userIds = [...new Set(paginatedPosts.map(p => p.userId))].filter(Boolean);
+    const users: User[] = [];
+    if (userIds.length > 0) {
+        const usersSnap = await db.collection('users').where('id', 'in', userIds).get();
+        usersSnap.docs.forEach(doc => users.push({ id: doc.id, ...(doc.data() as User) }));
+    }
+    const userDict = users.reduce((dict, u) => { dict[u.id] = u; return dict; }, {} as Record<string, User>);
+
+    const imageUrls = getImageUrls(paginatedPosts, 's');
+    const posts = paginatedPosts.map((post, i) => ({
+        ...post,
+        images: imageUrls[i],
+        formattedUpdateDate: uiDateFormat(post.updateDate),
+        author: userDict[post.userId],
+    }));
+
+    return { posts, totalCount };
+}
+
+export async function getPaginatedNewsAdmin(
+    args: { limit: number; page: number }
+): Promise<{ news: NewsArticle[]; totalCount: number }> {
+    const db = getAdminFirestore();
+    const snapshot = await db.collection('news')
+        .orderBy('expireAt', 'desc')
+        .get();
+
+    const allNews = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as NewsArticle) }));
+    const deduped = dedupeBySimilarTitle(allNews).sort((a, b) =>
+        new Date(b.publishedAt || 0).getTime() - new Date(a.publishedAt || 0).getTime()
+    );
+
+    const totalCount = deduped.length;
+    const start = (args.page - 1) * args.limit;
+    const news = deduped.slice(start, start + args.limit).map(article => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { expireAt, ...rest } = article;
+        return { ...rest, formattedPubDate: uiDateFormat(new Date(article.publishedAt).getTime()) };
+    });
+
+    return { news, totalCount };
+}


### PR DESCRIPTION
…to use admin SDK

- Added Firestore type import and new helper functions getAdminFirestore() and adminGetDocument() in firebaseAdmin.ts
- Updated album pages to use admin SDK for fetching album and user data instead of regular Firestore queries
- Replaced queryOnce with direct Firestore collection queries using admin SDK
- Removed unused imports from album pages
- Updated getStaticPaths and getStaticProps to use new admin Firestore utilities
- Updated account pages to use admin Firestore for fetching user data and posts
- Improved consistency by using admin SDK throughout album and account related pages